### PR TITLE
fix: handle namespaced elements

### DIFF
--- a/src/prettify.js
+++ b/src/prettify.js
@@ -148,7 +148,7 @@ const process = (html, config) => {
 
   /* Remove line returns, tabs, and consecutive spaces within html elements or their content. */
   html = html.replace(
-    />[^<]*?[^><\/\s][^<]*?<\/|>\s+[^><\s]|<script[^>]*>\s+<\/script>|<(\w+)>\s+<\/(\w+)|<([\w:\-]+)[^>]*[^\/]>\s+<\/([\w:\-]+)>/g,
+    />[^<]*?[^><\/\s][^<]*?<\/|>\s+[^><\s]|<script[^>]*>\s+<\/script>|<(\w+)>\s+<\/(\w+)|<(?:([\w:\-]+)|([\w:\-]+)[^>]*[^\/])>\s+<\/([\w:\-]+)>/g,
     match => match.replace(/\n|\t|\s{2,}/g, '')
   )
 

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -148,7 +148,7 @@ const process = (html, config) => {
 
   /* Remove line returns, tabs, and consecutive spaces within html elements or their content. */
   html = html.replace(
-    />[^<]*?[^><\/\s][^<]*?<\/|>\s+[^><\s]|<script[^>]*>\s+<\/script>|<(\w+)>\s+<\/(\w+)|<([\w\-]+)[^>]*[^\/]>\s+<\/([\w\-]+)>/g,
+    />[^<]*?[^><\/\s][^<]*?<\/|>\s+[^><\s]|<script[^>]*>\s+<\/script>|<(\w+)>\s+<\/(\w+)|<([\w:\-]+)[^>]*[^\/]>\s+<\/([\w:\-]+)>/g,
     match => match.replace(/\n|\t|\s{2,}/g, '')
   )
 

--- a/tests/all.spec.js
+++ b/tests/all.spec.js
@@ -18,7 +18,8 @@ title="We need your email for verification." name="email" required><!--    This 
 <label for="fruits-1-0"  >Apples<  /label><br><div><!--      This is an embedded comment. --></div>
 <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes">
 <label for="fruits-1-1">Grapes</label><br></fieldset>
-<br>
+<br><name:test></name:test>
+<link:test><div>Hello There</div></link:test>
 </form>`
 
 const entify_html = `<textarea  >
@@ -49,6 +50,10 @@ const pretty_html = `<form id="3">
     <br />
   </fieldset>
   <br />
+  <name:test></name:test>
+  <link:test>
+    <div>Hello There</div>
+  </link:test>
 </form>`
 
 const pretty_strict_html = `<form id="3">
@@ -65,6 +70,10 @@ const pretty_strict_html = `<form id="3">
     <br>
   </fieldset>
   <br>
+  <name:test></name:test>
+  <link:test>
+    <div>Hello There</div>
+  </link:test>
 </form>`
 
 const pretty_wrapped_html = `<form id="3">
@@ -92,6 +101,10 @@ const pretty_wrapped_html = `<form id="3">
     <br />
   </fieldset>
   <br />
+  <name:test></name:test>
+  <link:test>
+    <div>Hello There</div>
+  </link:test>
 </form>`
 
 const pretty_wrapped_tab4_html = `<form id="3">
@@ -119,6 +132,10 @@ const pretty_wrapped_tab4_html = `<form id="3">
         <br />
     </fieldset>
     <br />
+    <name:test></name:test>
+    <link:test>
+        <div>Hello There</div>
+    </link:test>
 </form>`
 
 const pretty_wrapped_strict_html = `<form id="3">
@@ -141,11 +158,15 @@ const pretty_wrapped_strict_html = `<form id="3">
     <br>
   </fieldset>
   <br>
+  <name:test></name:test>
+  <link:test>
+    <div>Hello There</div>
+  </link:test>
 </form>`
 
 const closify_html = `<form id="3">
 <!-- This is a comment. -->
-<!-- This is a second comment. --><br><input><br><input></form>`
+<!-- This is a second comment. --><br><input><br><input><link:test></link:test></form>`
 
 const config_html = `<form id="3">
 <!-- This is a comment. -->
@@ -243,7 +264,7 @@ test('Prettify with empty attributes', () => {
 
 test('Minify', () => {
   expect(minify(pretty_html)).toBe(
-    `<form id="3"><!-- This is a comment. --><!-- This is a second comment. --><label for="email-0">What's your email?</label><input id="email-0" type="email" title="We need your email for verification." name="email" required /><!-- This is another comment. --><label for="1">What fruits do you like?</label><fieldset id="1"><input id="fruits-1-0" type="checkbox" name="fruits" value="apples" /><label for="fruits-1-0">Apples</label><br /><div><!-- This is an embedded comment. --></div><input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" /><label for="fruits-1-1">Grapes</label><br /></fieldset><br /></form>`
+    `<form id="3"><!-- This is a comment. --><!-- This is a second comment. --><label for="email-0">What's your email?</label><input id="email-0" type="email" title="We need your email for verification." name="email" required /><!-- This is another comment. --><label for="1">What fruits do you like?</label><fieldset id="1"><input id="fruits-1-0" type="checkbox" name="fruits" value="apples" /><label for="fruits-1-0">Apples</label><br /><div><!-- This is an embedded comment. --></div><input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" /><label for="fruits-1-1">Grapes</label><br /></fieldset><br /><name:test></name:test><link:test><div>Hello There</div></link:test></form>`
   )
 })
 
@@ -271,7 +292,7 @@ test('Closify', () => {
   expect(closify(closify_html)).toBe(
 `<form id="3">
 <!-- This is a comment. -->
-<!-- This is a second comment. --><br /><input /><br /><input /></form>`
+<!-- This is a second comment. --><br /><input /><br /><input /><link:test></link:test></form>`
   )
 })
 


### PR DESCRIPTION
Allows for HTML element names that are namespaced with a colon. e.g `<name:test></name:test>`.