### PR TITLE
refactor: make ignore process faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "htmlfy",
-	"version": "0.7.3",
+	"version": "0.7.4",
 	"description": "HTML formatter yo! Prettify, minify, and more!",
 	"scripts": {
 		"check": "tsc",


### PR DESCRIPTION
Instead of replacing characters that will be ignored during other processing, we now extract the whole thing and then re-insert it later. This bypasses the need to process that part of the string, resulting in much faster results - especially for large code blocks.