### PR TITLE
fix: text siblings punctuation handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "htmlfy",
-	"version": "0.7.4",
+	"version": "0.7.5",
 	"description": "HTML formatter yo! Prettify, minify, and more!",
 	"scripts": {
 		"check": "tsc",

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -150,6 +150,25 @@ const process = (html, config) => {
     const current_indent_level = offset // Store the level for this line
 
     indents = indents.substring(0, current_indent_level) // Adjust for *next* round
+
+    /**
+     * Starts with a single punctuation character.
+     * Add punctuation to end of previous line.
+     * 
+     * TODO - Implement inline groups instead?
+     */
+    if (source.type === 'text' && /^[!,;\.]/.test(current_line_value)) {
+      if (current_line_value.length === 1) {
+        output_lines[output_lines.length - 1] = 
+          output_lines.at(-1) + current_line_value
+        return
+      } else {
+        output_lines[output_lines.length - 1] = 
+          output_lines.at(-1) + current_line_value.charAt(0)
+        current_line_value = current_line_value.slice(1).trim()
+      }
+    }
+
     const padding = step.repeat(current_indent_level)
 
     if (is_ignored_content) {

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -516,6 +516,14 @@ const pretty_leading_plaintext_sibling = `<mg-input-text
     <mg-icon icon="magnifying-glass"></mg-icon>
   </mg-button>
 </mg-input-text>`
+const surrounded_plaintext_sibling = `<div>The panda <i>eats</i>, <i>shoots</i>, and <i>leaves</i>.</div>`
+const pretty_surrounded_plaintext_sibling = `<div>
+  The panda
+  <i>eats</i>,
+  <i>shoots</i>,
+  and
+  <i>leaves</i>.
+</div>`
 
 const heavy_plaintext = `<div>Hello There World<br />Goodbye Now</div><div><i></i> Simmer<span>Down</span>Y'all </div>`
 const pretty_heavy_plaintext = `<div>
@@ -621,6 +629,11 @@ test('Trailing plaintext sibling', () => {
 test('Leading plaintext sibling', () => {
   // @ts-ignore // convert to number in v0.9.0
   expect(prettify(leading_plaintext_sibling, { tag_wrap: true })).toBe(pretty_leading_plaintext_sibling)
+})
+
+test('Surrounded plaintext sibling', () => {
+  // @ts-ignore // convert to number in v0.9.0
+  expect(prettify(surrounded_plaintext_sibling)).toBe(pretty_surrounded_plaintext_sibling)
 })
 
 test('Heavy plaintext nesting', () => {


### PR DESCRIPTION
If a text node starts with a simple punctuation mark (comma, semicolon, period, exclamation point), ensure it's at the end of the previous line.

We should probably implement better processing of inline-type elements, instead of simply having the elements and text siblings on separate lines.

fixes #28 