### PR TITLE
breaking: release v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # htmlfy
-HTML formatter yo! Prettify, minify and more!
+HTML formatter yo!
 
-`htmlfy` is a fork of [html-formatter](https://github.com/uznam8x/html-formatter/tree/master). Some of the processing logic has been preserved, and full credit for that goes to the original author. I've made the following major enhancements.
+Prettier html, minified html, and a few more goodies.
+
+`htmlfy` is a fork of [html-formatter](https://github.com/uznam8x/html-formatter/tree/master). Some of the processing logic has been preserved, and full credit for that goes to the original author.
+
+I've made the following enhancements:
 
 - Fully typed
 - Converted to ESM
-- Introduced configuration options
-- Added support for custom HTML elements (web components)
-- Lots of refactoring
+- Configuration options
+- Support for custom HTML elements (web components)
+- Refactoring galore
 - Made it go brrr fast
 
 ## Install
@@ -79,7 +83,7 @@ console.log(closify(html))
 ```
 
 ### Entify
-A standalone function that enforces entity characters for textarea content. You can pass `minify` as `true` to minify the tags themselves. Note that this does not run the HTML through the `minify` function.
+A standalone function that enforces entity characters for textarea content. You can pass `true ` as the `minify` to minify the tags themselves. Note that this does not run the HTML through the `minify` function.
 
 ```js
 import { entify } from 'htmlfy'
@@ -94,7 +98,7 @@ This is another paragraph.
 </textarea><textarea class="  more  stuff  ">    </textarea>`
 console.log(entify(html, true))
 /*
-<main class="hello   there world"><div>Welcome to htmlfy!  </div></main><textarea>Did you know that 3 &gt; 2?&#13;&#13;This is another paragraph.</textarea><textarea class="more stuff"></textarea>
+<main class="hello   there world"><div>Welcome to htmlfy!  </div></main><textarea>&#10;&#10;Did&nbsp;&nbsp;&nbsp;you&nbsp;know&nbsp;that&nbsp;3&nbsp;&gt;&nbsp;&nbsp;&nbsp;2?&#10;&#10;This&nbsp;is&nbsp;another&nbsp;paragraph.&nbsp;&nbsp;&nbsp;&#10;&#10;&#10;</textarea><textarea class="more stuff">&nbsp;&nbsp;&nbsp;&nbsp;</textarea>
 */
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # htmlfy
 HTML formatter yo! Prettify, minify and more!
 
-`htmlfy` is a fork of [html-formatter](https://github.com/uznam8x/html-formatter/tree/master). A lot of the processing logic has been preserved, and full credit for that goes to the original author. I've made the following major enhancements.
+`htmlfy` is a fork of [html-formatter](https://github.com/uznam8x/html-formatter/tree/master). Some of the processing logic has been preserved, and full credit for that goes to the original author. I've made the following major enhancements.
 
-- Fully typed.
-- Converted to ESM.
-- Added configuration options.
+- Fully typed
+- Converted to ESM
+- Introduced configuration options
 - Added support for custom HTML elements (web components)
-- Lots of refactoring.
-- Made it go brrr fast.
+- Lots of refactoring
+- Made it go brrr fast
 
 ## Install
 
 `npm install htmlfy`
 
 ## API
-Most projects will only need to use `prettify` and/or `minify`.
 
 ### Prettify
-Turn single-line or ugly HTML into highly formatted HTML. This is a wrapper for all other functions, except `trimify`, and then it adds indentation.
+Turn single-line or ugly HTML into highly formatted HTML. You can pass a configuration object as the second argument.
 
 ```js
 import { prettify } from 'htmlfy'
@@ -35,9 +34,9 @@ console.log(prettify(html))
 ```
 
 ### Minify
-Turn well-formatted or ugly HTML into a single line of HTML.
+Turn well-formatted or ugly HTML into a single line of HTML. You can pass a configuration object as the second argument. This function is called internally when you use `prettify`.
 
-> This feature is not a replacement for compressors like [htmlnano](https://github.com/posthtml/htmlnano), which focus on giving you the smallest data-size possible; but rather, it simply removes tabs, returns, and redundant whitespace.
+> This feature is not a replacement for compressors like [htmlnano](https://github.com/posthtml/htmlnano), which focus on giving you the smallest data-size possible.
 
 ```js
 import { minify } from 'htmlfy'
@@ -55,9 +54,7 @@ console.log(minify(html))
 ```
 
 ### Closify
-> This is done when using prettify, but you can use it in a one-off scenario if needed.
-
-Ensure [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) are "self-closing".
+A standalone function that ensures [void elements](https://developer.mozilla.org/en-US/docs/Glossary/Void_element) are "self-closing".
 
 ```js
 import { closify } from 'htmlfy'
@@ -69,10 +66,20 @@ console.log(closify(html))
 */
 ```
 
-### Entify
-> This is done when using prettify, but you can use it in a one-off scenario if needed.
+It also normalizes non-void elements which happen to be self-closing for whatever reason.
 
-Enforce entity characters for textarea content. This also performs basic minification on textareas before setting entities. When running this function as a standalone, you'll likely want to pass `minify` as `true` for full minification of the textarea. The minification does not process any other tags.
+```js
+import { closify } from 'htmlfy'
+
+const html = `<form class="hello" />`
+console.log(closify(html))
+/*
+<form class="hello"></form>
+*/
+```
+
+### Entify
+A standalone function that enforces entity characters for textarea content. You can pass `minify` as `true` to minify the tags themselves. Note that this does not run the HTML through the `minify` function.
 
 ```js
 import { entify } from 'htmlfy'
@@ -92,16 +99,16 @@ console.log(entify(html, true))
 ```
 
 ### Trimify
-Trim leading and trailing whitespace for whatever HTML element(s) you'd like. This is a standalone function, which is not run with `prettify` by default.
+A standalone function that trims leading and trailing whitespace for whatever HTML elements you'd like.
 
 ```js
 import { trimify } from 'htmlfy'
 
 const html = `<div>
-Hello World
+Hello    World
 </div>`
-console.log(trimify(html, [ 'div' ]))
-/* <div>Hello World</div> */
+console.log(trimify(html, ['div']))
+/* <div>Hello    World</div> */
 ```
 
 ### Default Import
@@ -156,19 +163,19 @@ console.log(prettify(html, { content_wrap: 40 }))
 ```
 
 ### Ignore
-Tell htmlfy to not process some elements and leave them as-is.
+Tell htmlfy to not process some elements' content and leave them as-is. Note this still minifies the tags themselves.
 
 ```js
 import { prettify } from 'htmlfy'
 
 const html = `
 <main><div>Hello World</div></main>
-<style>
+<style  >
 body {
   width: 100
 }
 </style>`
-console.log(prettify(html, { ignore: [ 'style' ] }))
+console.log(prettify(html, { ignore: ['style'] }))
 /*
 <main>
   <div>
@@ -184,10 +191,10 @@ body {
 ```
 
 ### Ignore With
-You can pass in your own string, for ignoring elements, if the default is actually being used in your ignored elements.
+You can pass in your own string, for ignoring elements, if the default is actually being used in the elements you want to ignore.
 
 ```js
-prettify(html, { ignore: [ 'p' ], ignore_with: 'some-string-that-wont-be-in-your-ignored-elements' })
+prettify(html, { ignore: ['p'], ignore_with: 'some-string-that-wont-be-in-your-ignored-elements' })
 ```
 
 ### Strict
@@ -247,14 +254,12 @@ console.log(prettify(html, { tag_wrap: 40 }))
 ```
 
 ### Trim
-Trim leading and trailing whitespace within `textarea` elements, since all whitespace is preserved by default.
+Trim leading and trailing whitespace within elements. Good for when you are ignoring certain elements, but still want to remove this whitespace.
 
 ```js
 import { prettify } from 'htmlfy'
 
-const html = '<textarea>    Hello World    </textarea>'
-console.log(prettify(html, { trim: [ 'textarea' ]}))
-/*<textarea>Hello&nbsp;World</textarea>*/
+const html = '<textarea>    Hello   World    </textarea>'
+console.log(prettify(html, { trim: ['textarea'], ignore: ['textarea']}))
+/*<textarea>Hello   World</textarea>*/
 ```
-
-> For compatibility and possible future expansion, we require declaring an array with the value 'textarea', as opposed to using something like `{ trim: true }`. Passing in additional HTML element values has no real effect, since we already trim whitespace for all other elements.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "htmlfy",
-	"version": "0.8.1",
-	"description": "HTML formatter yo! Prettify, minify, and more!",
+	"version": "1.0.0",
+	"description": "html formatter yo! Prettify or minify html.",
 	"main": "./src/exports/index.js",
 	"scripts": {
 		"check": "tsc",
@@ -29,9 +29,9 @@
 		"url": "git+https://github.com/j4w8n/htmlfy.git"
 	},
 	"keywords": [
-		"HTML",
 		"format",
-		"formatter",
+		"html",
+		"pretty",
 		"prettier",
 		"minifier",
 		"prettify",

--- a/src/closify.js
+++ b/src/closify.js
@@ -4,18 +4,21 @@ import { isHtml } from "./utils.js"
 
 /**
  * Ensure void elements are "self-closing".
+ * Also transforms self-closing, non-void elements
+ * into opening/closing elements.
  * 
  * @param {string} html The HTML string to evaluate.
  * @returns {string}
  * @example <br> => <br />
+ * @example <form /> => <form></form>
  */
 export const closify = (html) => {
   const { checked_html } = getState()
   
   if (!checked_html && !isHtml(html)) return html
-  
+
   return html.replace(/<([a-zA-Z\-0-9:]+)[^>]*>/g, (match, name) => {
-    if (VOID_ELEMENTS.indexOf(name) > -1)
+    if (VOID_ELEMENTS.includes(name))
       return (`${match.substring(0, match.length - 1)} />`).replace(/\/\s\//g, '/')
 
     return match.replace(/[\s]?\/>/g, `></${name}>`)

--- a/src/constants.js
+++ b/src/constants.js
@@ -14,7 +14,7 @@ export const CONFIG = {
 
 export const CONTENT_IGNORE_STRING = '__!i-£___£%__'
 export const SELF_CLOSING_PLACEHOLDER = '__!//-£___£%//__>'
-export const IGNORE_STRING = '!i-£___£%_'
+export const ATTRIBUTE_IGNORE_STRING = '!i-£___£%_'
 
 export const VOID_ELEMENTS = [
   'area', 'base', 'br', 'col', 'embed', 'hr', 

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@
 export const CONFIG = {
   content_wrap: 0,
   ignore: [],
-  ignore_with: '_!i-£___£%_',
+  ignore_with: '!i-£___£%',
   strict: false,
   tab_size: 2,
   tag_wrap: 0,
@@ -12,12 +12,16 @@ export const CONFIG = {
   trim: []
 }
 
-export const CONTENT_IGNORE_STRING = '__!i-£___£%__'
-export const SELF_CLOSING_PLACEHOLDER = '__!//-£___£%//__>'
-export const ATTRIBUTE_IGNORE_STRING = '!i-£___£%_'
-
 export const VOID_ELEMENTS = [
   'area', 'base', 'br', 'col', 'embed', 'hr', 
   'img', 'input', 'link', 'meta',
   'param', 'source', 'track', 'wbr'
 ]
+
+/**
+ * Defined by state.js and configuration.
+ * 
+ * CONTENT_IGNORE_PLACEHOLDER
+ * SELF_CLOSING_PLACEHOLDER
+ * ATTRIBUTE_IGNORE_PLACEHOLDER
+ */

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,7 +4,7 @@
 export const CONFIG = {
   content_wrap: 0,
   ignore: [],
-  ignore_with: '!i-£___£%',
+  ignore_with: '!i-£___£%_',
   strict: false,
   tab_size: 2,
   tag_wrap: 0,

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,6 +13,7 @@ export const CONFIG = {
 }
 
 export const CONTENT_IGNORE_STRING = '__!i-£___£%__'
+export const SELF_CLOSING_PLACEHOLDER = '__!//-£___£%//__>'
 export const IGNORE_STRING = '!i-£___£%_'
 
 export const VOID_ELEMENTS = [

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,6 @@ export const CONFIG = {
   strict: false,
   tab_size: 2,
   tag_wrap: 0,
-  tag_wrap_width: 80,
   trim: []
 }
 

--- a/src/entify.js
+++ b/src/entify.js
@@ -3,17 +3,19 @@
  * To also minifiy, pass `minify` as `true`.
  * 
  * @param {string} html The HTML string to evaluate.
- * @param {boolean} [minify] Fully minifies the content of textarea elements. 
+ * @param {boolean} [minify] Minifies the textarea tags themselves. 
  * Defaults to `false`. We recommend a value of `true` if you're running `entify()` 
  * as a standalone function.
  * @returns {string}
- * @example <textarea>3 > 2</textarea> => <textarea>3 &gt; 2</textarea>
+ * @example <textarea>3 > 2</textarea> => <textarea>3&nbsp;&gt;&nbsp;2</textarea>
+ * @example With minify.
+ * <textarea  >3 > 2</textarea> => <textarea>3&nbsp;&gt;&nbsp;2</textarea>
  */
 export const entify = (html, minify = false) => {
   /** 
    * Use entities inside textarea content.
    */
-  html = html.replace(/<textarea[^>]*>((.|\n)*?)<\/textarea>/g, (match, capture) => {
+  html = html.replace(/<\s*textarea[^>]*>((.|\n)*?)<s*\/\s*textarea\s*>/g, (match, capture) => {
     return match.replace(capture, (match) => {
       return match
         .replace(/</g, '&lt;')
@@ -28,27 +30,49 @@ export const entify = (html, minify = false) => {
 
   /* Typical minification, but only for textareas. */
   if (minify) {
-    html = html.replace(/<textarea[^>]*>((.|\n)*?)<\/textarea>/g, (match, capture) => {
-      /* Replace things inside the textarea content. */
-      match = match.replace(capture, (match) => {
-        return match
-          .replace(/\n|\t/g, '')
-          .replace(/[a-z]+="\s*"/ig, '')
-          .replace(/>\s+</g, '><')
-          .replace(/\s+/g, ' ')
-      })
-
-      /* Replace things in the entire element */
-      match = match
+    html = html.replace(/<\s*textarea[^>]*>((.|\n)*?)<\s*\/\s*textarea\s*>/g, (match, capture) => {
+      /* This only affects the html tags, since everything else has been entified. */
+      return match
         .replace(/\s+/g, ' ')
         .replace(/\s>/g, '>')
         .replace(/>\s/g, '>')
         .replace(/\s</g, '<')
+        .replace(/<\s/g, '<')
+        .replace(/<\/\s/g, '<\/')
         .replace(/class=["']\s/g, (match) => match.replace(/\s/g, ''))
         .replace(/(class=.*)\s(["'])/g, '$1'+'$2')
-      return match
     })
   }
 
   return html
+}
+
+/**
+ * Remove entity characters for textarea content.
+ * Currently internal use only.
+ * 
+ * @param {string} html The HTML string to evaluate.
+ * @returns {string}
+ * @example <textarea>3&nbsp;&gt;&nbsp;2</textarea> => <textarea>3 > 2</textarea>
+ */
+export const dentify = (html) => {
+  /** 
+   * Remove entities inside textarea content.
+   */
+  return html = html.replace(/<textarea[^>]*>((.|\n)*?)<\/textarea>/g, (match, capture) => {
+    return match.replace(capture, (match) => {
+      match = match
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&#10;/g, '\n')
+        .replace(/&#13;/g, '\r')
+        .replace(/&nbsp;/g, ' ')
+        // Ensure we collapse consecutive spaces, or they'll be completely removed later.
+        .replace(/\s+/g, ' ')
+
+      return match
+    })
+  })
 }

--- a/src/entify.js
+++ b/src/entify.js
@@ -1,6 +1,6 @@
 /**
  * Enforce entity characters for textarea content.
- * To also minifiy, pass `minify` as `true`.
+ * To also minifiy tags, pass `minify` as `true`.
  * 
  * @param {string} html The HTML string to evaluate.
  * @param {boolean} [minify] Minifies the textarea tags themselves. 
@@ -28,9 +28,8 @@ export const entify = (html, minify = false) => {
     })
   })
 
-  /* Typical minification, but only for textareas. */
   if (minify) {
-    html = html.replace(/<\s*textarea[^>]*>((.|\n)*?)<\s*\/\s*textarea\s*>/g, (match, capture) => {
+    html = html.replace(/<\s*textarea[^>]*>(.|\n)*?<\s*\/\s*textarea\s*>/g, (match) => {
       /* This only affects the html tags, since everything else has been entified. */
       return match
         .replace(/\s+/g, ' ')

--- a/src/minify.js
+++ b/src/minify.js
@@ -1,4 +1,4 @@
-import { entify } from "./entify.js"
+import { dentify, entify } from "./entify.js"
 import { extractIgnoredBlocks, isHtml, reinsertIgnoredBlocks, validateConfig } from "./utils.js"
 import { getState } from "./state.js"
 
@@ -33,10 +33,10 @@ export const minify = (html, config) => {
   }
 
   /**
-   * Ensure textarea content is specially minified and protected
+   * Ensure textarea content is protected
    * before general minification.
    */
-  html = entify(html)
+  html = entify(html, true)
 
   /* All other minification. */
   // Remove ALL newlines and tabs explicitly.
@@ -48,11 +48,13 @@ export const minify = (html, config) => {
   // Collapse any remaining multiple spaces to single spaces.
   html = html.replace(/ {2,}/g, ' ')
 
-  // Remove specific single spaces OR whitespace within closing tags.
+  // Remove specific single spaces between tags and whitespace within tags.
   html = html.replace(/ >/g, ">")   // <tag > -> <tag>
-  html = html.replace(/ </g, "<")   // Text < -> Text< (Also handles leading space before tag)
-  html = html.replace(/> /g, ">")   // > Text -> >Text
-  html = html.replace(/<\s*\//g, '</') // < /tag -> </tag>
+  html = html.replace(/ </g, "<")   // leading space before tag
+  html = html.replace(/> /g, ">")   // trailing space after tag
+  html = html.replace(/< /g, "<")   // < tag> -> <tag>
+  html = html.replace(/<\s+\//g, '</') // < /tag> -> </tag>
+  html = html.replace(/<\/\s+/g, '</') // </ tag> -> </tag>
 
   // Trim spaces around equals signs in attributes (run before value trim)
   //    This handles `attr = "value"` -> `attr="value"`
@@ -72,6 +74,9 @@ export const minify = (html, config) => {
 
   // Final trim for the whole string
   html = html.trim()
+
+  /* Remove protective entities. */
+  html = dentify(html)
 
   /* Re-insert ignored elements. Skipped unless minify did the ignore. */
   if (reinsert_ignored) {

--- a/src/minify.js
+++ b/src/minify.js
@@ -26,7 +26,7 @@ export const minify = (html, config) => {
 
   /* Extract ignored elements. Skipped if prettify has already ignored blocks. */
   if (!ignored && ignore) {
-    const { html_with_markers, extracted_map } = extractIgnoredBlocks(html, validated_config);
+    const { html_with_markers, extracted_map } = extractIgnoredBlocks(html)
     html = html_with_markers
     ignore_map = extracted_map
     reinsert_ignored = true

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -83,8 +83,6 @@ const process = (config) => {
   const step = " ".repeat(config.tab_size)
   const tag_wrap = config.tag_wrap
   const content_wrap = config.content_wrap
-  const ignore_with = config.ignore_with
-  const placeholder_template = `-${ignore_with}`
   const strict = config.strict
 
   /* Track current number of indentations needed. */
@@ -100,12 +98,6 @@ const process = (config) => {
     let current_line_value = source.value
 
     const is_ignored_content =
-      current_line_value.startsWith(placeholder_template + "lt--") ||
-      current_line_value.startsWith(placeholder_template + "gt--") ||
-      current_line_value.startsWith(placeholder_template + "nl--") ||
-      current_line_value.startsWith(placeholder_template + "cr--") ||
-      current_line_value.startsWith(placeholder_template + "ws--") ||
-      current_line_value.startsWith(placeholder_template + "tab--") ||
       current_line_value.startsWith('___HTMLFY_SPECIAL_IGNORE_MARKER_')
 
     let subtrahend = 0

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -68,10 +68,6 @@ const enqueue = (html) => {
  * @returns {string}
  */
 const preprocess = (html) => {
-  const { config } = getState()
-
-  if (config.trim.length > 0) html = trimify(html, config.trim)
-
   html = minify(html)
   html = enqueue(html)
 
@@ -109,7 +105,8 @@ const process = (config) => {
       current_line_value.startsWith(placeholder_template + "nl--") ||
       current_line_value.startsWith(placeholder_template + "cr--") ||
       current_line_value.startsWith(placeholder_template + "ws--") ||
-      current_line_value.startsWith(placeholder_template + "tab--")
+      current_line_value.startsWith(placeholder_template + "tab--") ||
+      current_line_value.startsWith('___HTMLFY_SPECIAL_IGNORE_MARKER_')
 
     let subtrahend = 0
     const prev_line_data = convert.line[index - 1]
@@ -282,9 +279,12 @@ export const prettify = (html, config) => {
   const validated_config = config ? validateConfig(config) : { ...CONFIG }
   const ignore = validated_config.ignore.length > 0
 
+  /* Allows you to trimify before ignoring. */
+  if (validated_config.trim.length > 0) html = trimify(html, validated_config.trim)
+
   /* Extract ignored elements. */
   if (!ignored && ignore) {
-    const { html_with_markers, extracted_map } = extractIgnoredBlocks(html, validated_config);
+    const { html_with_markers, extracted_map } = extractIgnoredBlocks(html, validated_config)
     html = html_with_markers
     ignore_map = extracted_map
     reinsert_ignored = true

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -15,7 +15,7 @@ import {
   validateConfig, 
   wordWrap
 } from './utils.js'
-import { CONFIG, SELF_CLOSING_PLACEHOLDER, VOID_ELEMENTS } from './constants.js'
+import { CONFIG, VOID_ELEMENTS } from './constants.js'
 import { getState } from './state.js'
 
 /**
@@ -84,6 +84,7 @@ const process = (config) => {
   const tag_wrap = config.tag_wrap
   const content_wrap = config.content_wrap
   const strict = config.strict
+  const { constants } = getState()
 
   /* Track current number of indentations needed. */
   let indents = ''
@@ -120,7 +121,7 @@ const process = (config) => {
     if (
       prev_line_value.trim().endsWith("/>") // native self-closing
       ||
-      prev_line_value.trim().endsWith(SELF_CLOSING_PLACEHOLDER) // synthetic self-closing
+      prev_line_value.trim().endsWith(constants.SELF_CLOSING_PLACEHOLDER) // synthetic self-closing
     ) subtrahend++
     /* prevLine is a closing tag. */
     if (prev_line_value.trim().startsWith("</")) subtrahend++
@@ -222,7 +223,7 @@ const process = (config) => {
   if (tag_wrap > 0) final_html = protectAttributes(final_html)
 
   /* Extra preserve wrapped content. */
-  if (content_wrap > 0 && /\n[ ]*[^\n]*__!i-£___£%__[^\n]*\n/.test(final_html))
+  if (content_wrap > 0 && new RegExp(`/\\n[ ]*[^\\n]*${constants.CONTENT_IGNORE_PLACEHOLDER}[^\\n]*\\n/`).test(final_html))
     final_html = finalProtectContent(final_html)
 
   /* Remove line returns, tabs, and consecutive spaces within html elements or their content. */
@@ -230,7 +231,7 @@ const process = (config) => {
     /<(?<Element>[^>\s]+)[^>]*>[^<]*?[^><\/\s][^<]*?<\/\k<Element>>|<script[^>]*>[\s]*<\/script>|<([\w:\._-]+)([^>]*)><\/\2>|<([\w:\._-]+)([^>]*)>[\s]+<\/\4>/g,
     match => {
       // Check if this contains placeholder
-      if (match.includes(SELF_CLOSING_PLACEHOLDER)) {
+      if (match.includes(constants.SELF_CLOSING_PLACEHOLDER) || match.includes(constants.CONTENT_IGNORE_PLACEHOLDER)) {
         return match // Don't modify if it contains the placeholder
       }
 

--- a/src/state.js
+++ b/src/state.js
@@ -26,7 +26,7 @@ const state = {
   constants: {
     CONTENT_IGNORE_PLACEHOLDER: `${CONFIG.ignore_with}_`,
     SELF_CLOSING_PLACEHOLDER: `${CONFIG.ignore_with}/_>`,
-    ATTRIBUTE_IGNORE_PLACEHOLDER: `${CONFIG.ignore_with}`
+    ATTRIBUTE_IGNORE_PLACEHOLDER: `${CONFIG.ignore_with}=_`
   }
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -1,19 +1,33 @@
 import { CONFIG } from "./constants.js"
 
 /**
+ * @typedef {object} Constants
+ * @property {string} CONTENT_IGNORE_PLACEHOLDER
+ * @property {string} SELF_CLOSING_PLACEHOLDER
+ * @property {string} ATTRIBUTE_IGNORE_PLACEHOLDER
+ */
+/**
  * @typedef {object} State
  * @property {boolean} checked_html - If passed in HTML has been checked for HTML within it.
  * @property {import("htmlfy").Config} config - Validated configuration.
  * @property {boolean} ignored
+ * @property {Constants} constants - Constant strings, influenced by ignore_with.
  */
 
 /**
  * @type State
+ * 
+ * `constants` prefixes and suffixes must be in sync with those in utils.js
  */
 const state = {
   checked_html: false,
   config: { ...CONFIG },
-  ignored: false
+  ignored: false,
+  constants: {
+    CONTENT_IGNORE_PLACEHOLDER: `${CONFIG.ignore_with}_`,
+    SELF_CLOSING_PLACEHOLDER: `${CONFIG.ignore_with}/_>`,
+    ATTRIBUTE_IGNORE_PLACEHOLDER: `${CONFIG.ignore_with}`
+  }
 }
 
 /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import { IGNORE_STRING, CONFIG, CONTENT_IGNORE_STRING } from './constants.js'
+import { IGNORE_STRING, CONFIG, CONTENT_IGNORE_STRING, VOID_ELEMENTS, SELF_CLOSING_PLACEHOLDER } from './constants.js'
 import { setState } from './state.js'
 
 /**
@@ -535,4 +535,31 @@ export function reinsertIgnoredBlocks(html_with_markers, extracted_map) {
     final_html = final_html.split(marker).join(original_block)
   }
   return final_html
+}
+
+const void_element_regex = new RegExp(`<(${VOID_ELEMENTS.join("|")})(?:\\s(?:[^/>]|/(?!>))*)*>`, 'g')
+
+/**
+ * Add a placeholder for void elements that are not self-closing.
+ * This is for internal processing only.
+ * 
+ * @param {string} html 
+ * @returns 
+ */
+export function setSelfClosing(html) {
+  return html.replace(
+    // match only void elements that are not self-closing
+    void_element_regex,
+    match => match.replace(/>$/, SELF_CLOSING_PLACEHOLDER)
+  )
+}
+
+/**
+ * Remove internal placeholder for non-native self-closing void elements.
+ * 
+ * @param {string} html 
+ * @returns 
+ */
+export function unsetSelfClosing(html) {
+  return html.replace(SELF_CLOSING_PLACEHOLDER, ">")
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,7 +136,7 @@ export const finalProtectContent = (html) => {
       const protected_text = text_to_protect
        .replace(/\n/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'nl!')
        .replace(/\r/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'cr!')
-       .replace(/\s/g, constants.CONTENT_IGNORE_PLACEHOLDER + "ws!");
+       .replace(/\s/g, constants.CONTENT_IGNORE_PLACEHOLDER + "ws!")
 
       return match.replace(text_to_protect, protected_text)
     })
@@ -392,11 +392,11 @@ export const wordWrap = (text, width, indent) => {
  * for re-insertion later.
  * 
  * @param {string} html 
- * @param {import('htmlfy').Config} config 
  * @returns {{ html_with_markers: string, extracted_map: Map<any,any> }}
  */
-export function extractIgnoredBlocks(html, config) {
+export function extractIgnoredBlocks(html) {
   setState({ ignored: true })
+  const config = (getState()).config
   let current_html = html
   const extracted_blocks = new Map()
   let marker_id = 0

--- a/src/utils.js
+++ b/src/utils.js
@@ -302,7 +302,7 @@ export const validateConfig = (config) => {
   }
 
   if (Object.hasOwn(config, 'content_wrap') && typeof config.content_wrap !== 'number')
-    throw new Error(`content_wrap config must be a number, not ${typeof config.tag_wrap_width}.`)
+    throw new Error(`content_wrap config must be a number, not ${typeof config.content_wrap}.`)
 
   if (Object.hasOwn(config, 'ignore') && (!Array.isArray(config.ignore) || !config.ignore?.every((e) => typeof e === 'string')))
     throw new Error('Ignore config must be an array of strings.')
@@ -320,26 +320,9 @@ export const validateConfig = (config) => {
 
   if (Object.hasOwn(config, 'strict') && typeof config.strict !== 'boolean')
     throw new Error(`Strict config must be a boolean, not ${typeof config.strict}.`)
-
-  /* TODO remove in v0.9.0 */
-  if (Object.hasOwn(config, 'tag_wrap') && typeof config.tag_wrap === 'boolean') {
-    console.warn('tag_wrap as a boolean is deprecated, and will not be supported in v0.9.0+. Use `tag_wrap: <number>` instead; where <number> is the max character width acceptable before wrapping attributes.')
-    if (config.tag_wrap_width)
-      config.tag_wrap = config.tag_wrap_width
-    else
-      config.tag_wrap = default_config.tag_wrap_width
-  }
   
   if (Object.hasOwn(config, 'tag_wrap') && typeof config.tag_wrap !== 'number')
     throw new Error(`tag_wrap config must be a number, not ${typeof config.tag_wrap}.`)
-
-  /* TODO remove in v0.9.0 */
-  if (Object.hasOwn(config, 'tag_wrap_width'))
-    console.warn('tag_wrap_width is deprecated, and will not be supported in v0.9.0+. Use `tag_wrap: <number>` instead; where <number> is the max character width acceptable before wrapping attributes.')
-
-  /* TODO remove in v0.9.0 */
-  if (Object.hasOwn(config, 'tag_wrap_width') && typeof config.tag_wrap_width !== 'number')
-    throw new Error(`tag_wrap_width config must be a number, not ${typeof config.tag_wrap_width}.`)
 
   if (Object.hasOwn(config, 'trim') && (!Array.isArray(config.trim) || !config.trim?.every((e) => typeof e === 'string')))
     throw new Error('Trim config must be an array of strings.')

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
-import { ATTRIBUTE_IGNORE_STRING, CONFIG, CONTENT_IGNORE_STRING, VOID_ELEMENTS, SELF_CLOSING_PLACEHOLDER } from './constants.js'
-import { setState } from './state.js'
+import { CONFIG, VOID_ELEMENTS } from './constants.js'
+import { getState, setState } from './state.js'
 
 /**
  * Checks if content contains at least one HTML element or custom HTML element.
@@ -73,7 +73,16 @@ const mergeObjects = (current, updates) => {
  */
 export const mergeConfig = (default_config, config) => {
   const validated_config = mergeObjects(default_config, config)
-  setState({ config: validated_config })
+
+  /* Below `constants` prefixes and suffixes must be in sync with those in state.js */
+  setState({ 
+    config: validated_config,
+    constants: {
+      CONTENT_IGNORE_PLACEHOLDER: `${validated_config.ignore_with}_`,
+      SELF_CLOSING_PLACEHOLDER: `${validated_config.ignore_with}/_>`,
+      ATTRIBUTE_IGNORE_PLACEHOLDER: `${validated_config.ignore_with}`
+    }
+  })
   return validated_config
 }
 
@@ -82,12 +91,14 @@ export const mergeConfig = (default_config, config) => {
  * @param {string} html 
  */
 export const protectAttributes = (html) => {
+  const { constants } = getState()
+
   html = html.replace(/<[\w:\-]+([^>]*[^\/])>/g, (/** @type {string} */match, /** @type {any} */capture) => {
     return match.replace(capture, (match) => {
       return match
-        .replace(/\n/g, ATTRIBUTE_IGNORE_STRING + 'nl!')
-        .replace(/\r/g, ATTRIBUTE_IGNORE_STRING + 'cr!')
-        .replace(/\s/g, ATTRIBUTE_IGNORE_STRING + 'ws!')
+        .replace(/\n/g, constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'nl!')
+        .replace(/\r/g, constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'cr!')
+        .replace(/\s/g, constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'ws!')
     })
   })
 
@@ -99,10 +110,12 @@ export const protectAttributes = (html) => {
  * @param {string} html 
  */
 export const protectContent = (html) => {
+  const { constants } = getState()
+
   return html
-    .replace(/\n/g, CONTENT_IGNORE_STRING + 'nl!')
-    .replace(/\r/g, CONTENT_IGNORE_STRING + 'cr!')
-    .replace(/\s/g, CONTENT_IGNORE_STRING + 'ws!')
+    .replace(/\n/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'nl!')
+    .replace(/\r/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'cr!')
+    .replace(/\s/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'ws!')
 }
 
 /**
@@ -110,7 +123,9 @@ export const protectContent = (html) => {
  * @param {string} html 
  */
 export const finalProtectContent = (html) => {
-  const regex = /\s*<([a-zA-Z0-9:-]+)[^>]*>\n\s*<\/\1>(?=\n[ ]*[^\n]*__!i-£___£%__[^\n]*\n)(\n[ ]*\S[^\n]*\n)|<([a-zA-Z0-9:-]+)[^>]*>(?=\n[ ]*[^\n]*__!i-£___£%__[^\n]*\n)(\n[ ]*\S[^\n]*\n\s*)<\/\3>/g
+  const regex = /\s*<([a-zA-Z0-9:-]+)[^>]*>\n\s*<\/\1>(?=\n[ ]*[^\n]*__!i-£___£%__[^\n]*\n)(\n[ ]*\S[^\n]*\n)|<([a-zA-Z0-9:-]+)[^>]*>(?=\n[ ]*[^\n]*__!i-£___£%__[^\n]*\n)(\n[ ]*\S[^\n]*\n\s*)<\/\3>/g 
+  const { constants } = getState()
+
   return html
     .replace(regex, (/** @type {string} */match, p1, p2, p3, p4) => {
       const text_to_protect = p2 || p4
@@ -119,9 +134,9 @@ export const finalProtectContent = (html) => {
         return match
 
       const protected_text = text_to_protect
-       .replace(/\n/g, CONTENT_IGNORE_STRING + 'nl!')
-       .replace(/\r/g, CONTENT_IGNORE_STRING + 'cr!')
-       .replace(/\s/g, CONTENT_IGNORE_STRING + "ws!");
+       .replace(/\n/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'nl!')
+       .replace(/\r/g, constants.CONTENT_IGNORE_PLACEHOLDER + 'cr!')
+       .replace(/\s/g, constants.CONTENT_IGNORE_PLACEHOLDER + "ws!");
 
       return match.replace(text_to_protect, protected_text)
     })
@@ -134,13 +149,14 @@ export const finalProtectContent = (html) => {
  * @returns {string}
  */
 export const setIgnoreAttribute = (html) => {
-  const regex = /<([A-Za-z][A-Za-z0-9]*|[a-z][a-z0-9._]*-[a-z0-9._-]+)((?:\s+[A-Za-z0-9_-]+="[^"]*"|\s*[a-z]*)*)>/g
+  const regex = /<([A-Za-z][A-Za-z0-9]*|[a-z][a-z0-9._]*-[a-z0-9._-]+)((?:\s+[A-Za-z0-9_-]+="[^"]*"|\s*[a-z]*)*)>/g 
+  const { constants } = getState()
 
   html = html.replace(regex, (/** @type {string} */match, p1, p2) => {
     return match.replace(p2, (match) => {
       return match
-        .replace(/</g, ATTRIBUTE_IGNORE_STRING + 'lt!')
-        .replace(/>/g, ATTRIBUTE_IGNORE_STRING + 'gt!')
+        .replace(/</g, constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'lt!')
+        .replace(/>/g, constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'gt!')
     })
   })
   
@@ -173,12 +189,14 @@ export const trimify = (html, trim) => {
  * @param {string} html 
  */
 export const unprotectAttributes = (html) => {
+  const { constants } = getState()
+
   html = html.replace(/<[\w:\-]+([^>]*[^\/])>/g, (/** @type {string} */match, /** @type {any} */capture) => {
     return match.replace(capture, (match) => {
       return match
-        .replace(new RegExp(ATTRIBUTE_IGNORE_STRING + 'nl!', "g"), '\n')
-        .replace(new RegExp(ATTRIBUTE_IGNORE_STRING + 'cr!', "g"), '\r')
-        .replace(new RegExp(ATTRIBUTE_IGNORE_STRING + 'ws!', "g"), ' ')
+        .replace(new RegExp(constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'nl!', "g"), '\n')
+        .replace(new RegExp(constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'cr!', "g"), '\r')
+        .replace(new RegExp(constants.ATTRIBUTE_IGNORE_PLACEHOLDER + 'ws!', "g"), ' ')
     })
   })
 
@@ -190,24 +208,19 @@ export const unprotectAttributes = (html) => {
  * @param {string} html 
  */
 export const unprotectContent = (html) => {
-  html = html.replace(/.*__!i-£___£%__[a-z]{2}!.*/g, (/** @type {string} */match) => {
-    return match.replace(/__!i-£___£%__[a-z]{2}!/g, (match) => {
+  const { constants } = getState()
+
+  html = html.replace(new RegExp(`.*${constants.CONTENT_IGNORE_PLACEHOLDER}[a-z]{2}!.*`, "g"), (/** @type {string} */match) => {
+    return match.replace(new RegExp(`${constants.CONTENT_IGNORE_PLACEHOLDER}[a-z]{2}!`, "g"), (match) => {
       return match
-        .replace(new RegExp(CONTENT_IGNORE_STRING + 'nl!', "g"), '\n')
-        .replace(new RegExp(CONTENT_IGNORE_STRING + 'cr!', "g"), '\r')
-        .replace(new RegExp(CONTENT_IGNORE_STRING + 'ws!', "g"), ' ')
+        .replace(new RegExp(constants.CONTENT_IGNORE_PLACEHOLDER + 'nl!', "g"), '\n')
+        .replace(new RegExp(constants.CONTENT_IGNORE_PLACEHOLDER + 'cr!', "g"), '\r')
+        .replace(new RegExp(constants.CONTENT_IGNORE_PLACEHOLDER + 'ws!', "g"), ' ')
     })
   })
 
   return html
 }
-
-const escapedIgnoreString = ATTRIBUTE_IGNORE_STRING.replace(
-  /[-\/\\^$*+?.()|[\]{}]/g,
-  "\\$&"
-);
-const ltPlaceholderRegex = new RegExp(escapedIgnoreString + "lt!", "g");
-const gtPlaceholderRegex = new RegExp(escapedIgnoreString + "gt!", "g");
 
 /**
  * Replace ignore string with html brackets.
@@ -218,6 +231,13 @@ const gtPlaceholderRegex = new RegExp(escapedIgnoreString + "gt!", "g");
 export const unsetIgnoreAttribute = (html) => {
   /* Regex to find opening tags and capture their attributes. */
   const tagRegex = /<([\w:\-]+)([^>]*)>/g
+  const { constants } = getState()
+  const escapedIgnoreString = constants.ATTRIBUTE_IGNORE_PLACEHOLDER.replace(
+    /[-\/\\^$*+?.()|[\]{}]/g,
+    "\\$&"
+  )
+  const ltPlaceholderRegex = new RegExp(escapedIgnoreString + "lt!", "g")
+  const gtPlaceholderRegex = new RegExp(escapedIgnoreString + "gt!", "g")
 
   return html.replace(
     tagRegex,
@@ -287,8 +307,16 @@ export const validateConfig = (config) => {
   if (Object.hasOwn(config, 'ignore') && (!Array.isArray(config.ignore) || !config.ignore?.every((e) => typeof e === 'string')))
     throw new Error('Ignore config must be an array of strings.')
 
-  if (Object.hasOwn(config, 'ignore_with') && typeof config.ignore_with !== 'string')
-    throw new Error(`Ignore_with config must be a string, not ${typeof config.ignore_with}.`)
+  if (Object.hasOwn(config, 'ignore_with')) {
+    if (typeof config.ignore_with !== 'string')
+      throw new Error(`ignore_with must be a string, not ${typeof config.ignore_with}.`)
+    else if (config.ignore_with.startsWith('_') || config.ignore_with.endsWith('_'))
+      /**
+       * This negatively affects processing of preserved tag attributes,
+       * but I'm not sure why.
+       */
+      throw new Error(`ignore_with cannot start or end with an underscore.`)
+  }
 
   if (Object.hasOwn(config, 'strict') && typeof config.strict !== 'boolean')
     throw new Error(`Strict config must be a boolean, not ${typeof config.strict}.`)
@@ -461,10 +489,12 @@ const void_element_regex = new RegExp(`<(${VOID_ELEMENTS.join("|")})(?:\\s(?:[^/
  * @returns 
  */
 export function setSelfClosing(html) {
+  const { constants } = getState()
+
   return html.replace(
     // match only void elements that are not self-closing
     void_element_regex,
-    match => match.replace(/>$/, SELF_CLOSING_PLACEHOLDER)
+    match => match.replace(/>$/, constants.SELF_CLOSING_PLACEHOLDER)
   )
 }
 
@@ -475,5 +505,7 @@ export function setSelfClosing(html) {
  * @returns 
  */
 export function unsetSelfClosing(html) {
-  return html.replace(SELF_CLOSING_PLACEHOLDER, ">")
+  const { constants } = getState()
+
+  return html.replace(constants.SELF_CLOSING_PLACEHOLDER, ">")
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -80,7 +80,7 @@ export const mergeConfig = (default_config, config) => {
     constants: {
       CONTENT_IGNORE_PLACEHOLDER: `${validated_config.ignore_with}_`,
       SELF_CLOSING_PLACEHOLDER: `${validated_config.ignore_with}/_>`,
-      ATTRIBUTE_IGNORE_PLACEHOLDER: `${validated_config.ignore_with}`
+      ATTRIBUTE_IGNORE_PLACEHOLDER: `${validated_config.ignore_with}=_`
     }
   })
   return validated_config
@@ -274,7 +274,6 @@ export const validateConfig = (config) => {
     Object.hasOwn(config, 'strict') || 
     Object.hasOwn(config, 'tab_size') || 
     Object.hasOwn(config, 'tag_wrap') || 
-    Object.hasOwn(config, 'tag_wrap_width') || 
     Object.hasOwn(config, 'trim')
   )
 
@@ -310,12 +309,13 @@ export const validateConfig = (config) => {
   if (Object.hasOwn(config, 'ignore_with')) {
     if (typeof config.ignore_with !== 'string')
       throw new Error(`ignore_with must be a string, not ${typeof config.ignore_with}.`)
-    else if (config.ignore_with.startsWith('_') || config.ignore_with.endsWith('_'))
+    else if (config.ignore_with.startsWith('_'))
       /**
        * This negatively affects processing of preserved tag attributes,
-       * but I'm not sure why.
+       * because tag names can end with an underscore, so the regex
+       * does not capture them.
        */
-      throw new Error(`ignore_with cannot start or end with an underscore.`)
+      throw new Error(`ignore_with cannot start with an underscore.`)
   }
 
   if (Object.hasOwn(config, 'strict') && typeof config.strict !== 'boolean')

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -41,21 +41,21 @@ const pretty_html = `<form id="3">
   <!-- This is a comment. -->
   <!-- This is a second comment. -->
   <label for="email-0">What's your email?</label>
-  <input id="email-0" type="email" title="We need your email for verification." name="email" required />
+  <input id="email-0" type="email" title="We need your email for verification." name="email" required>
   <!-- This is another comment. -->
   <label for="1">What fruits do you like?</label>
   <fieldset id="1">
-    <input id="fruits-1-0" type="checkbox" name="fruits" value="apples" />
+    <input id="fruits-1-0" type="checkbox" name="fruits" value="apples">
     <label for="fruits-1-0">Apples</label>
-    <br />
+    <br>
     <div>
       <!-- This is an embedded comment. -->
     </div>
-    <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" />
+    <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes">
     <label for="fruits-1-1">Grapes</label>
-    <br />
+    <br>
   </fieldset>
-  <br />
+  <br>
   <name:test></name:test>
   <link:test>
     <div>Hello There</div>
@@ -138,21 +138,21 @@ const pretty_wrapped_html = `<form id="3">
     title="We need your email for verification."
     name="email"
     required
-  />
+  >
   <!-- This is another comment. -->
   <label for="1">What fruits do you like?</label>
   <fieldset id="1">
-    <input id="fruits-1-0" type="checkbox" name="fruits" value="apples" />
+    <input id="fruits-1-0" type="checkbox" name="fruits" value="apples">
     <label for="fruits-1-0">Apples</label>
-    <br />
+    <br>
     <div>
       <!-- This is an embedded comment. -->
     </div>
-    <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" />
+    <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes">
     <label for="fruits-1-1">Grapes</label>
-    <br />
+    <br>
   </fieldset>
-  <br />
+  <br>
   <name:test></name:test>
   <link:test>
     <div>Hello There</div>
@@ -195,21 +195,21 @@ const pretty_wrapped_tab4_html = `<form id="3">
         title="We need your email for verification."
         name="email"
         required
-    />
+    >
     <!-- This is another comment. -->
     <label for="1">What fruits do you like?</label>
     <fieldset id="1">
-        <input id="fruits-1-0" type="checkbox" name="fruits" value="apples" />
+        <input id="fruits-1-0" type="checkbox" name="fruits" value="apples">
         <label for="fruits-1-0">Apples</label>
-        <br />
+        <br>
         <div>
             <!-- This is an embedded comment. -->
         </div>
-        <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" />
+        <input id="fruits-1-1" type="checkbox" name="fruits" value="grapes">
         <label for="fruits-1-1">Grapes</label>
-        <br />
+        <br>
     </fieldset>
-    <br />
+    <br>
     <name:test></name:test>
     <link:test>
         <div>Hello There</div>
@@ -366,7 +366,7 @@ const standalone_pretty_input_wrap = `<input
   type="checkbox"
   name="fruits"
   value="apples"
-/>`
+>`
 
 const attribute_with_html_crazy_name = '<cus---t0m...element___ boolean text="hello" blu="blu bli bla blo" number="42" html-content="Help text with html <b>bold</b>, <em>italic</em>."></cus---t0m...element___>'
 const attribute_with_html_crazy_name_tag_wrap = '<cus---t0m...element___ boolean text="hello" blu="blu bli bla blo" number="42" html-content="Help text with html <b>bold</b>, <em>italic</em>."></cus---t0m...element___>'
@@ -749,7 +749,7 @@ test('Elements with multiple standalone attributes and tag wrap', () => {
 
 test('Minify', () => {
   expect(minify(pretty_html)).toBe(
-    `<form id="3"><!-- This is a comment. --><!-- This is a second comment. --><label for="email-0">What's your email?</label><input id="email-0" type="email" title="We need your email for verification." name="email" required /><!-- This is another comment. --><label for="1">What fruits do you like?</label><fieldset id="1"><input id="fruits-1-0" type="checkbox" name="fruits" value="apples" /><label for="fruits-1-0">Apples</label><br /><div><!-- This is an embedded comment. --></div><input id="fruits-1-1" type="checkbox" name="fruits" value="grapes" /><label for="fruits-1-1">Grapes</label><br /></fieldset><br /><name:test></name:test><link:test><div>Hello There</div></link:test><custom-element class="hello there world" style="margin-top: 12px; margin-left: 12px;"><div>Goodbye World</div></custom-element></form><link:test>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</link:test><mg-card>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</mg-card>`
+    `<form id="3"><!-- This is a comment. --><!-- This is a second comment. --><label for="email-0">What's your email?</label><input id="email-0" type="email" title="We need your email for verification." name="email" required><!-- This is another comment. --><label for="1">What fruits do you like?</label><fieldset id="1"><input id="fruits-1-0" type="checkbox" name="fruits" value="apples"><label for="fruits-1-0">Apples</label><br><div><!-- This is an embedded comment. --></div><input id="fruits-1-1" type="checkbox" name="fruits" value="grapes"><label for="fruits-1-1">Grapes</label><br></fieldset><br><name:test></name:test><link:test><div>Hello There</div></link:test><custom-element class="hello there world" style="margin-top: 12px; margin-left: 12px;"><div>Goodbye World</div></custom-element></form><link:test>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</link:test><mg-card>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</mg-card>`
   )
 })
 

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -921,7 +921,7 @@ test('Default ignore_with in HTML', () => {
   <div>
     <br />
     <input />
-    <p>This contains &lt;angled&gt; brackets -_!i-£___£%_gt- and an unfortunate combination of characters</p>
+    <p>This contains &lt;angled&gt; brackets -${CONFIG.ignore_with}gt- and an unfortunate combination of characters</p>
     <input />
     <div></div>
   </div>
@@ -931,6 +931,10 @@ test('Default ignore_with in HTML', () => {
 
 test('Catches invalid ignore config', async () => {
   await expect(testConfig({ ignore: [ 'script', 1 ]})).rejects.toThrow('Ignore config must be an array of strings.')
+})
+
+test('Catches invalid ignore_with config', async () => {
+  await expect(testConfig({ ignore_with: '_hello_'})).rejects.toThrow('ignore_with cannot start or end with an underscore.')
 })
 
 test('Catches invalid trim config', async () => {

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -28,14 +28,22 @@ title="We need your email for verification." name="email" required><!--    This 
 <link:test>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</link:test>
 <mg-card>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</mg-card>`
 
-const entify_html = `<textarea  >
+const single_textarea_html = `<   textarea  >
 
 Did   you know that 3 >   2?
 
 This is another paragraph.   
 
 
-</textarea><textarea class="  more  stuff  ">    </textarea>`
+</  textarea   >`
+const textarea_html = `<   textarea  >
+
+Did   you know that 3 >   2?
+
+This is another paragraph.   
+
+
+</  textarea   ><textarea class="  more  stuff  ">    </textarea>`
 
 const pretty_html = `<form id="3">
   <!-- This is a comment. -->
@@ -647,8 +655,8 @@ test('Custom elements with heavy plaintext nesting', () => {
 test('Trimify', () => {
   expect(trimify(trim_leading_whitespace, ['div'])).toBe('<div>Hello</div>')
   expect(trimify(trim_trailing_whitespace, ['div'])).toBe('<div>Hello</div>')
-  expect(prettify(entify_html, { trim: [ 'textarea' ]})).toBe(
-    `<textarea>Did&nbsp;&nbsp;&nbsp;you&nbsp;know&nbsp;that&nbsp;3&nbsp;&gt;&nbsp;&nbsp;&nbsp;2?&#10;&#10;This&nbsp;is&nbsp;another&nbsp;paragraph.</textarea>
+  expect(prettify(textarea_html)).toBe(
+    `<textarea>Did you know that 3 > 2? This is another paragraph.</textarea>
 <textarea class="more stuff"></textarea>`
   )
 })
@@ -789,8 +797,8 @@ text
 })
 
 test('Entify', () => {
-  expect(entify(entify_html)).toBe(
-    `<textarea  >&#10;&#10;Did&nbsp;&nbsp;&nbsp;you&nbsp;know&nbsp;that&nbsp;3&nbsp;&gt;&nbsp;&nbsp;&nbsp;2?&#10;&#10;This&nbsp;is&nbsp;another&nbsp;paragraph.&nbsp;&nbsp;&nbsp;&#10;&#10;&#10;</textarea><textarea class="  more  stuff  ">&nbsp;&nbsp;&nbsp;&nbsp;</textarea>`
+  expect(entify(textarea_html)).toBe(
+    `<   textarea  >&#10;&#10;Did&nbsp;&nbsp;&nbsp;you&nbsp;know&nbsp;that&nbsp;3&nbsp;&gt;&nbsp;&nbsp;&nbsp;2?&#10;&#10;This&nbsp;is&nbsp;another&nbsp;paragraph.&nbsp;&nbsp;&nbsp;&#10;&#10;&#10;</  textarea   ><textarea class="  more  stuff  ">&nbsp;&nbsp;&nbsp;&nbsp;</textarea>`
   )
 })
 
@@ -799,7 +807,7 @@ test('Entify with plain text', () => {
 })
 
 test('Entify with minify', () => {
-  expect(entify(entify_html, true)).toBe(
+  expect(entify(textarea_html, true)).toBe(
     `<textarea>&#10;&#10;Did&nbsp;&nbsp;&nbsp;you&nbsp;know&nbsp;that&nbsp;3&nbsp;&gt;&nbsp;&nbsp;&nbsp;2?&#10;&#10;This&nbsp;is&nbsp;another&nbsp;paragraph.&nbsp;&nbsp;&nbsp;&#10;&#10;&#10;</textarea><textarea class="more stuff">&nbsp;&nbsp;&nbsp;&nbsp;</textarea>`
   )
 })
@@ -814,6 +822,33 @@ test('Closify', () => {
 
 test('Closify with HTML check', () => {
   expect(closify('No HTML')).toBe('No HTML')
+})
+
+test('Ignore textarea tag', () => {
+  expect(prettify(single_textarea_html, { ignore: [ 'textarea' ]})).toBe(
+    `<textarea>
+
+Did   you know that 3 >   2?
+
+This is another paragraph.   
+
+
+</textarea>`
+  )
+})
+
+test('Ignore consecutive textarea tags', () => {
+  expect(prettify(textarea_html, { ignore: [ 'textarea' ]})).toBe(
+    `<textarea>
+
+Did   you know that 3 >   2?
+
+This is another paragraph.   
+
+
+</textarea>
+<textarea class="more stuff">    </textarea>`
+  )
 })
 
 test('Ignore script tag', () => {

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -304,7 +304,8 @@ const pretty_wrapped_strict_html = `<form id="3">
 
 const closify_html = `<form id="3">
 <!-- This is a comment. -->
-<!-- This is a second comment. --><br><input><br><input><link:test></link:test></form>`
+<form id="test" />
+<!-- This is a second comment. --><br><input class="hello"><br><input><link:test></link:test></form>`
 
 const config_html = `<form id="3">
 <!-- This is a comment. -->
@@ -807,7 +808,8 @@ test('Closify', () => {
   expect(closify(closify_html)).toBe(
 `<form id="3">
 <!-- This is a comment. -->
-<!-- This is a second comment. --><br /><input /><br /><input /><link:test></link:test></form>`
+<form id="test"></form>
+<!-- This is a second comment. --><br /><input class="hello" /><br /><input /><link:test></link:test></form>`
   )
 })
 

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -925,7 +925,7 @@ test('Catches invalid ignore config', async () => {
 })
 
 test('Catches invalid ignore_with config', async () => {
-  await expect(testConfig({ ignore_with: '_hello_'})).rejects.toThrow('ignore_with cannot start or end with an underscore.')
+  await expect(testConfig({ ignore_with: '_hello_'})).rejects.toThrow('ignore_with cannot start with an underscore.')
 })
 
 test('Catches invalid trim config', async () => {

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -630,17 +630,14 @@ test('Sole namespaced custom element is HTML', () => {
 })
 
 test('Trailing plaintext sibling', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(trailing_plaintext_sibling, { tag_wrap: true })).toBe(pretty_trailing_plaintext_sibling)
+  expect(prettify(trailing_plaintext_sibling, { tag_wrap: 80 })).toBe(pretty_trailing_plaintext_sibling)
 })
 
 test('Leading plaintext sibling', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(leading_plaintext_sibling, { tag_wrap: true })).toBe(pretty_leading_plaintext_sibling)
+  expect(prettify(leading_plaintext_sibling, { tag_wrap: 80 })).toBe(pretty_leading_plaintext_sibling)
 })
 
 test('Surrounded plaintext sibling', () => {
-  // @ts-ignore // convert to number in v0.9.0
   expect(prettify(surrounded_plaintext_sibling)).toBe(pretty_surrounded_plaintext_sibling)
 })
 
@@ -674,8 +671,7 @@ test('Prettify with strict HTML', () => {
 })
 
 test('Prettify with tag wrap', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(ugly_html, { ...common_config, tag_wrap: true })).toBe(pretty_wrapped_html)
+  expect(prettify(ugly_html, { ...common_config, tag_wrap: 80 })).toBe(pretty_wrapped_html)
 })
 
 test('Prettify with content wrap', () => {
@@ -683,13 +679,11 @@ test('Prettify with content wrap', () => {
 })
 
 test('Prettify with tag wrap and tab size', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(ugly_html, { ...common_config, tag_wrap: true, tab_size: 4 })).toBe(pretty_wrapped_tab4_html)
+  expect(prettify(ugly_html, { ...common_config, tag_wrap: 80, tab_size: 4 })).toBe(pretty_wrapped_tab4_html)
 })
 
 test('Prettify with tag wrap and strict HTML', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(ugly_html, { ...common_config, strict: true, tag_wrap: true })).toBe(pretty_wrapped_strict_html)
+  expect(prettify(ugly_html, { ...common_config, strict: true, tag_wrap: 80 })).toBe(pretty_wrapped_strict_html)
 })
 
 test('Prettify with empty attributes', () => {
@@ -697,13 +691,11 @@ test('Prettify with empty attributes', () => {
 })
 
 test('Standalone tag wrap', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(standalone_tag_wrap, { tag_wrap: true })).toBe(standalone_pretty_tag_wrap)
+  expect(prettify(standalone_tag_wrap, { tag_wrap: 80 })).toBe(standalone_pretty_tag_wrap)
 })
 
 test('Standalone input wrap', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(standalone_input_wrap, { tag_wrap: true })).toBe(standalone_pretty_input_wrap)
+  expect(prettify(standalone_input_wrap, { tag_wrap: 80 })).toBe(standalone_pretty_input_wrap)
 })
 
 test('Attribute with html text for value', () => {
@@ -711,8 +703,7 @@ test('Attribute with html text for value', () => {
 })
 
 test('Tag wrapped attribute with html text for value', () => {
-  // @ts-ignore // convert to number in v0.9.0
-  expect(prettify(attribute_with_hyphen_tag_wrap, { tag_wrap: true })).toBe(attribute_with_hyphen_pretty_tag_wrap)
+  expect(prettify(attribute_with_hyphen_tag_wrap, { tag_wrap: 80 })).toBe(attribute_with_hyphen_pretty_tag_wrap)
 })
 
 test('Void attribute with html text for value', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,24 +14,25 @@ declare module 'htmlfy' {
 
   /**
    * Ensure void elements are "self-closing".
-   *
+   * 
    * @param {string} html The HTML string to evaluate.
-   * @returns An HTML string where void elements are formatted as self-closing.
+   * @returns {string}
    * @example <br> => <br />
    */
   export function closify(html: string): string
 
   /**
    * Enforce entity characters for textarea content.
-   * By default, this also does basic minification before setting entities.
-   * For full minification, pass `minify` as `true`.
+   * To also minifiy, pass `minify` as `true`.
    * 
    * @param {string} html The HTML string to evaluate.
-   * @param {boolean} [minify] Fully minifies the content of textarea elements. 
+   * @param {boolean} [minify] Minifies the textarea tags themselves. 
    * Defaults to `false`. We recommend a value of `true` if you're running `entify()` 
    * as a standalone function.
-   * @returns An HTML string where entities are enforced on the contents of textareas.
-   * @example <textarea>3 > 2</textarea> => <textarea>3 &gt; 2</textarea>
+   * @returns {string}
+   * @example <textarea>3 > 2</textarea> => <textarea>3&nbsp;&gt;&nbsp;2</textarea>
+   * @example With minify.
+   * <textarea  >3 > 2</textarea> => <textarea>3&nbsp;&gt;&nbsp;2</textarea>
    */
   export function entify(html: string, minify?: boolean): string
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -12,11 +12,14 @@ declare module 'htmlfy' {
   export type Config = Required<UserConfig>
 
   /**
-   * Ensure void elements are "self-closing".
+   * Ensure void elements are self-closing.
+   * Also transforms self-closing, non-void elements
+   * into opening/closing elements.
    * 
    * @param {string} html The HTML string to evaluate.
    * @returns {string}
    * @example <br> => <br />
+   * @example <form /> => <form></form>
    */
   export function closify(html: string): string
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,7 +6,6 @@ declare module 'htmlfy' {
     strict?: boolean;
     tab_size?: number;
     tag_wrap?: number;
-    tag_wrap_width?: number;
     trim?: string[];
   }
 


### PR DESCRIPTION
## breaking

- do not enforce self-closing void elements by default (closify)
- do not set entities within `textarea`s by default (entify) -- this means textareas are now minified; so, use the `ignore` config option if you want to preserve their whitespace.
- default `ignore_with` string has changed
- remove deprecated `tag_wrap_width` configuration option (use `tag_wrap` instead)