### PR TITLE
fix: whitespace around nested tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "htmlfy",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "html formatter yo! Prettify or minify html.",
 	"main": "./src/exports/index.js",
 	"scripts": {

--- a/src/minify.js
+++ b/src/minify.js
@@ -17,7 +17,7 @@ let ignore_map
  */
 export const minify = (html, config) => {
   let reinsert_ignored = false
-  const { checked_html, ignored } = getState()
+  const { checked_html, ignored, constants } = getState()
 
   if (!checked_html && !isHtml(html)) return html
 
@@ -48,6 +48,18 @@ export const minify = (html, config) => {
   // Collapse any remaining multiple spaces to single spaces.
   html = html.replace(/ {2,}/g, ' ')
 
+  // Protect space between text content and an opening tag (e.g., "text <a>")
+  html = html.replace(
+    /(\S) (<[a-zA-Z][a-zA-Z0-9_:-]*)/g,
+    `$1___MINIFY-PROTECTED-SPACE___$2`
+  )
+
+  // Protect space between a closing tag and text content (e.g., "</a> text")
+  html = html.replace(
+    /(<\/[a-zA-Z][a-zA-Z0-9_:-]*>) (\S)/g,
+    `$1___MINIFY-PROTECTED-SPACE___$2`
+  )
+
   // Remove specific single spaces between tags and whitespace within tags.
   html = html.replace(/ >/g, ">")   // <tag > -> <tag>
   html = html.replace(/ </g, "<")   // leading space before tag
@@ -55,6 +67,9 @@ export const minify = (html, config) => {
   html = html.replace(/< /g, "<")   // < tag> -> <tag>
   html = html.replace(/<\s+\//g, '</') // < /tag> -> </tag>
   html = html.replace(/<\/\s+/g, '</') // </ tag> -> </tag>
+
+  // Unprotect space around inner tags
+  html = html.replace(new RegExp('___MINIFY-PROTECTED-SPACE___', 'g'), ' ')
 
   // Trim spaces around equals signs in attributes (run before value trim)
   //    This handles `attr = "value"` -> `attr="value"`

--- a/src/prettify.js
+++ b/src/prettify.js
@@ -132,6 +132,9 @@ const process = () => {
         output_lines[output_lines.length - 1] = 
           output_lines.at(-1) + current_line_value.charAt(0)
         current_line_value = current_line_value.slice(1).trim()
+
+        /* If nothing left after extracting punctuation, skip this line. */
+        if (current_line_value.length === 0) return
       }
     }
 

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -505,7 +505,7 @@ const pretty_trailing_plaintext_sibling = `<mg-input-text
   <div>Hello</div>
   <mg-button slot="append-input" label="search">
     <mg-icon icon="magnifying-glass"></mg-icon>
-    Search
+     Search
   </mg-button>
 </mg-input-text>`
 const leading_plaintext_sibling = '<mg-input-text identifier="identifier" name="input-name" label="Label" type="search" icon="magnifying-glass" placeholder="placeholder" tooltip="This is a tooltip" help-text="Help text with html <b>bold</b>, <em>italic</em>."><div>Hello</div><mg-button slot="append-input" label="search"> Search<mg-icon icon="magnifying-glass"></mg-icon></mg-button></mg-input-text>'
@@ -527,7 +527,7 @@ const pretty_leading_plaintext_sibling = `<mg-input-text
 </mg-input-text>`
 const surrounded_plaintext_sibling = `<div>The panda <i>eats</i>, <i>shoots</i>, and <i>leaves</i>.</div>`
 const pretty_surrounded_plaintext_sibling = `<div>
-  The panda
+  The panda 
   <i>eats</i>,
   <i>shoots</i>,
   and
@@ -542,7 +542,7 @@ const pretty_heavy_plaintext = `<div>
 </div>
 <div>
   <i></i>
-  Simmer
+   Simmer
   <span>Down</span>
   Y'all
 </div>`
@@ -555,7 +555,7 @@ const pretty_custom_heavy_plaintext = `<name:test>
 </name:test>
 <link:test>
   <thing:one></thing:one>
-  Simmer
+   Simmer
   <thing:two>Down</thing:two>
   Y'all
 </link:test>`
@@ -584,6 +584,8 @@ const wrapped_content_wrap_siblings = `<div>
   occaecat cupidatat non proident, sunt in culpa qui officia
   deserunt mollit anim id est laborum.
 </div>`
+
+const preserve_whitespace_around_inner_tags = minify(`<p>Some text  <a-z target="_blank" rel="noopener noreferrer nofollow" href="mailto:firstname.lastname@domain.com">E-Mail Link</a-z> 's</p>`)
 
 const only_normal_element = "<div></div>"
 const only_void_element = '<input>'
@@ -786,6 +788,10 @@ text
   expect(minify(html_with_kbd, { ignore: [ 'kbd' ] })).toBe(html_with_kbd)
   expect(minify(html_with_var, { ignore: [ 'var' ] })).toBe(html_with_var)
   expect(minify(html_with_tt, { ignore: [ 'tt' ] })).toBe(html_with_tt)
+})
+
+test('Minify preserves whitespace around inner tags', () => {
+  expect(preserve_whitespace_around_inner_tags).toBe(`<p>Some text <a-z target="_blank" rel="noopener noreferrer nofollow" href="mailto:firstname.lastname@domain.com">E-Mail Link</a-z> 's</p>`)
 })
 
 test('Entify', () => {


### PR DESCRIPTION
Ensures that we preserve whitespace around nested tags. "preserve" meaning _a_ space will remain; this does not preserve multiple spaces.

This strategy also finally resolves https://github.com/j4w8n/htmlfy/issues/23#issuecomment-2771197396, which I had to rollback shortly after "fixing".

Doesn't really "break" any APIs, but does alter current/expected behavior - although the current behavior is not correct. Some may have hacked their way around the issue, and, after this PR, will no longer need to do so.

closes #39